### PR TITLE
use pathlib for join path instead of os.path.join

### DIFF
--- a/project_name/settings.py-tpl
+++ b/project_name/settings.py-tpl
@@ -7,7 +7,6 @@ https://docs.djangoproject.com/en/{{ docs_version }}/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/{{ docs_version }}/ref/settings/
 """
-import os
 from pathlib import Path
 
 from configurations import Configuration, values
@@ -75,7 +74,7 @@ class Common(Configuration):
     # Database
     # https://docs.djangoproject.com/en/{{ docs_version }}/ref/settings/#databases
     DATABASES = values.DatabaseURLValue(
-        'sqlite:///{}'.format(os.path.join(BASE_DIR, 'db.sqlite3'))
+        'sqlite:///{}'.format(BASE_DIR / 'db.sqlite3')
     )
 
     # Password validation
@@ -110,7 +109,7 @@ class Common(Configuration):
     # Static files (CSS, JavaScript, Images)
     # https://docs.djangoproject.com/en/{{ docs_version }}/howto/static-files/
     STATIC_URL = '/static/'
-    STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+    STATIC_ROOT = BASE_DIR / 'staticfiles'
     STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
     # Default primary key field type


### PR DESCRIPTION
After Django 3.0, BASE_DIR in settings.py is generated by pathlib (also in this template):
quote from [Django docs](https://docs.djangoproject.com/en/3.1/releases/3.1/#miscellaneous):
> The settings.py generated by the startproject command now uses pathlib.Path instead of os.path for building filesystem paths.

```py
BASE_DIR = Path(__file__).resolve().parent.parent
```

The proper way to join path with pathlib is like this:
> Build paths inside the project like this: BASE_DIR / 'subdir'.

But it was used the old os.path.join now.
Also, The pathlib library is included in all versions of python >= 3.4. and django supported this, so there is no compatibility issue.